### PR TITLE
Fix for ignored fPIC option

### DIFF
--- a/02-increase-cpuinfo-buffer-size.patch
+++ b/02-increase-cpuinfo-buffer-size.patch
@@ -1,0 +1,11 @@
+--- modules/NE10_init.c	2020-02-11 13:42:54.754327681 -0800
++++ modules/NE10_init_fixed.c	2020-02-11 13:43:47.201902486 -0800
+@@ -31,7 +31,7 @@
+ 
+ #include "NE10.h"
+ 
+-#define CPUINFO_BUFFER_SIZE  (1024*4)
++#define CPUINFO_BUFFER_SIZE  (1024*1024)
+ 
+ // This local variable indicates whether or not the running platform supports ARM NEON
+ ne10_result_t is_NEON_available = NE10_ERR;

--- a/02-increase-cpuinfo-buffer-size.patch
+++ b/02-increase-cpuinfo-buffer-size.patch
@@ -1,5 +1,7 @@
---- modules/NE10_init.c	2020-02-11 13:42:54.754327681 -0800
-+++ modules/NE10_init_fixed.c	2020-02-11 13:43:47.201902486 -0800
+diff --git a/modules/NE10_init.c b/modules/NE10_init.c
+index 8ed94f7..dc42a99 100644
+--- a/modules/NE10_init.c
++++ b/modules/NE10_init.c
 @@ -31,7 +31,7 @@
  
  #include "NE10.h"

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,11 +5,11 @@ from conans import ConanFile, CMake, tools
 
 class PahocConan(ConanFile):
     name = "Ne10"
-    version = "1.2.2-2018.11.15" # version number rarely changes, so add date
-    #source_subfolder = "sources"
+    version = "1.2.2-2018.11.15"  # version number rarely changes, so add date
+    # source_subfolder = "sources"
     scm = {
         "type": "git",
-        #"subfolder": source_subfolder,
+        # "subfolder": source_subfolder,
         "url": "https://github.com/projectNe10/Ne10.git",
         # latest commit, 2018.11.15 
         "revision": "1f059a764d0e1bc2481c0055c0e71538470baa83"
@@ -25,7 +25,7 @@ class PahocConan(ConanFile):
                        "fPIC": True}
     generators = "cmake"
     exports = "LICENSE"
-    exports_sources = ["01-build-c-only.patch"]
+    exports_sources = ["01-build-c-only.patch", "02-increase-cpuinfo-buffer-size.patch"]
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -42,7 +42,7 @@ class PahocConan(ConanFile):
                 armOnly = True
                 cmake.definitions["NE10_LINUX_TARGET_ARCH"] = "armv7"
                 cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = "arm"
-            elif self.settings.arch == "armv8": 
+            elif self.settings.arch == "armv8":
                 armOnly = True
                 cmake.definitions["NE10_LINUX_TARGET_ARCH"] = "aarch64"
                 cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = "arm"
@@ -56,6 +56,7 @@ class PahocConan(ConanFile):
 
     def build(self):
         tools.patch(patch_file="01-build-c-only.patch")
+        tools.patch(patch_file="02-increase-cpuinfo-buffer-size.patch")
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conans import ConanFile, CMake, tools
 
 
-class PahocConan(ConanFile):
+class Ne10Conan(ConanFile):
     name = "Ne10"
     version = "1.2.2-2020.02.11"  # version number rarely changes, so add date
     # source_subfolder = "sources"
@@ -11,7 +11,7 @@ class PahocConan(ConanFile):
         "type": "git",
         # "subfolder": source_subfolder,
         "url": "https://github.com/projectNe10/Ne10.git",
-        # latest commit, 2018.11.15 
+        # latest commit, 2018.11.15
         "revision": "1f059a764d0e1bc2481c0055c0e71538470baa83"
     }
 
@@ -38,6 +38,8 @@ class PahocConan(ConanFile):
         cmake = CMake(self)
         armOnly = False
         if self.settings.os == "Linux":
+            # Need to manually set this, as the CMake project has no 'conan_setup' step
+            cmake.definitions['CMAKE_POSITION_INDEPENDENT_CODE'] = self.options.fPIC
             if self.settings.arch == "armv7hf":
                 armOnly = True
                 cmake.definitions["NE10_LINUX_TARGET_ARCH"] = "armv7"
@@ -54,9 +56,12 @@ class PahocConan(ConanFile):
         cmake.configure()
         return cmake
 
-    def build(self):
+    def source(self):
+        # The repo is downloaded at this point
         tools.patch(patch_file="01-build-c-only.patch")
         tools.patch(patch_file="02-increase-cpuinfo-buffer-size.patch")
+
+    def build(self):
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import ConanFile, CMake, tools
 
 class PahocConan(ConanFile):
     name = "Ne10"
-    version = "1.2.2-2018.11.15"  # version number rarely changes, so add date
+    version = "1.2.2-2020.02.11"  # version number rarely changes, so add date
     # source_subfolder = "sources"
     scm = {
         "type": "git",


### PR DESCRIPTION
When using conan, the fPIC option is applied automatically only if using a generator.
In this case the conan package is a wrapper around a preexisting CMake project that never calls `conan_basic_setup`.
Because of this reason, we have to manually set `CMAKE_POSITION_INDEPENDENT_CODE` flag in the recipe.